### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,18 +10,18 @@ import (
 )
 
 var (
-	service = kingpin.Flag("service", "Name of Service to update.").Required().String()
-	image   = kingpin.Flag("image", "Name of Docker image to run.").String()
-	tag     = kingpin.Flag("tag", "Tag of Docker image to run.").String()
-	cluster = kingpin.Flag("cluster", "Name of ECS cluster.").Default("default").String()
-	task    = kingpin.Flag("task", "Name of task definition. Defaults to service name").String()
-	region  = kingpin.Flag("region", "Name of AWS region.").Default("us-east-1").OverrideDefaultFromEnvar("AWS_DEFAULT_REGION").String()
-	count   = kingpin.Flag("count", "Desired count of instantiations to place and run in service. Defaults to existing running count.").Default("-1").Int64()
-	nowait  = kingpin.Flag("nowait", "Disable waiting for all task definitions to start running").Bool()
+	service = kingpin.Flag("service", "Name of Service to update.").Short("s").Required().String()
+	image   = kingpin.Flag("image", "Name of Docker image to run.").Short("i").String()
+	tag     = kingpin.Flag("tag", "Tag of Docker image to run.").Short("T").String()
+	cluster = kingpin.Flag("cluster", "Name of ECS cluster.").Short("C").Default("default").String()
+	task    = kingpin.Flag("task", "Name of task definition. Defaults to service name").Short("t").String()
+	region  = kingpin.Flag("region", "Name of AWS region.").Short("r").Default("us-east-1").OverrideDefaultFromEnvar("AWS_DEFAULT_REGION").String()
+	count   = kingpin.Flag("count", "Desired count of instantiations to place and run in service. Defaults to existing running count.").Short("c").Default("-1").Int64()
+	nowait  = kingpin.Flag("nowait", "Disable waiting for all task definitions to start running").Short("n").Bool()
 )
 
 func main() {
-	kingpin.UsageTemplate(kingpin.CompactUsageTemplate).Version("1.0.3").Author("Travis Jeffery")
+	kingpin.UsageTemplate(kingpin.CompactUsageTemplate).Version("1.0.4").Author("Travis Jeffery")
 	kingpin.CommandLine.Help = "Update ECS service."
 	kingpin.Parse()
 


### PR DESCRIPTION
This change adds short-flags to the longer flags based on Kingpin's documentation. If I understand this correctly, the shortflags are _not_ case sensitive; this also works locally for me.

Don't have a test suite to verify against though, sorry!
