### PR TITLE
Do not require image to be provided

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,18 +27,23 @@ func New(region *string, logger *log.Logger) *Client {
 	}
 }
 
-// RegisterTaskDefinition updates the existing task definition's image.
-func (c *Client) RegisterTaskDefinition(task, image, tag *string) (string, error) {
+// RegisterTaskDefinition creates new task definition
+// image:tag is explicitly set to the task definition if it's provided.
+func (c *Client) RegisterTaskDefinition(task, image *string, tag *string) (string, error) {
 	defs, err := c.GetContainerDefinitions(task)
 	if err != nil {
 		return "", err
 	}
-	for _, d := range defs {
-		if strings.HasPrefix(*d.Image, *image) {
-			i := fmt.Sprintf("%s:%s", *image, *tag)
-			d.Image = &i
+
+	if *image != "" && *tag != "" {
+		for _, d := range defs {
+			if strings.HasPrefix(*d.Image, *image) {
+				i := fmt.Sprintf("%s:%s", *image, *tag)
+				d.Image = &i
+			}
 		}
 	}
+
 	input := &ecs.RegisterTaskDefinitionInput{
 		Family:               task,
 		ContainerDefinitions: defs,

--- a/main.go
+++ b/main.go
@@ -36,12 +36,10 @@ func main() {
 	arn := ""
 	var err error
 
-	if image != nil {
-		arn, err = c.RegisterTaskDefinition(task, image, tag)
-		if err != nil {
-			logger.Printf("[error] register task definition: %s\n", err)
-			return
-		}
+	arn, err = c.RegisterTaskDefinition(task, image, tag)
+	if err != nil {
+		logger.Printf("[error] register task definition: %s\n", err)
+		return
 	}
 
 	err = c.UpdateService(cluster, service, count, &arn)


### PR DESCRIPTION
Use data from the latest task definitions instead. It makes more sense especially when task definition has more than one containers/images defined.
