### PR TITLE
ecs-deploy should return with code "1" if error occurs

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 		arn, err = c.RegisterTaskDefinition(task, image, tag)
 		if err != nil {
 			logger.Printf("[error] register task definition: %s\n", err)
+			os.Exit(1)
 			return
 		}
 	}
@@ -49,6 +50,7 @@ func main() {
 	err = c.UpdateService(cluster, service, count, &arn)
 	if err != nil {
 		logger.Printf("[error] update service: %s\n", err)
+		os.Exit(1)
 		return
 	}
 
@@ -56,6 +58,7 @@ func main() {
 		err := c.Wait(cluster, service, &arn)
 		if err != nil {
 			logger.Printf("[error] wait: %s\n", err)
+			os.Exit(1)
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/travisjeffery/ecs-deploy/client"
+	"./client/"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/travisjeffery/ecs-deploy/client"
+	"github.com/Droplr/ecs-deploy/client"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 


### PR DESCRIPTION
Hi,
we're using ecs-deploy in our Jenkins and currently it's hard to determine if deploy failed or not.
This pull requests makes that the command will exit with return code "1" to signalize that it failed.