### PR TITLE
Fix task role passing

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 		arn, err = c.RegisterTaskDefinition(task, image, tag)
 		if err != nil {
 			logger.Printf("[error] register task definition: %s\n", err)
+			os.Exit(1)
 			return
 		}
 	}
@@ -49,6 +50,7 @@ func main() {
 	err = c.UpdateService(cluster, service, count, &arn)
 	if err != nil {
 		logger.Printf("[error] update service: %s\n", err)
+		os.Exit(1)
 		return
 	}
 
@@ -56,6 +58,7 @@ func main() {
 		err := c.Wait(cluster, service, &arn)
 		if err != nil {
 			logger.Printf("[error] wait: %s\n", err)
+			os.Exit(1)
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/travisjeffery/ecs-deploy/client"
+	"./client/"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"./client/"
+	"github.com/travisjeffery/ecs-deploy/client"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 


### PR DESCRIPTION
When deploying new service, TaskRoleARN is not being passed into newly created task definition. This PR fixes this.